### PR TITLE
Avoid NPE if DBF file opened without directory

### DIFF
--- a/src/main/java/nl/knaw/dans/common/dbflib/Util.java
+++ b/src/main/java/nl/knaw/dans/common/dbflib/Util.java
@@ -141,7 +141,9 @@ class Util
             extension = ".dbt";
         }
 
-        final String parentDirName = dbfFile.getParent();
+        String parentDirName = dbfFile.getParent();
+        if (parentDirName == null)
+            parentDirName = dbfFile.getAbsoluteFile().getParent();
         final File parentDir = new File(parentDirName);
         final String dbfBaseName = stripExtension(dbfFile.getName());
 

--- a/src/test/java/nl/knaw/dans/common/dbflib/TestUtil.java
+++ b/src/test/java/nl/knaw/dans/common/dbflib/TestUtil.java
@@ -156,6 +156,17 @@ public class TestUtil
      * See test method name.
      */
     @Test
+    public void getDbtFile_if_no_directory()
+    {
+        File dbtFile = Util.getMemoFile(new File("x.DBF"),
+                                        Version.DBASE_5);
+        assertNull("Found non-existing .DBT", dbtFile);
+    }
+
+    /**
+     * See test method name.
+     */
+    @Test
     public void getNumberOfDigits()
     {
         assertEquals(1,


### PR DESCRIPTION
Avoid NullPointerException opening .dbt MEMO file when .dbf file is opened without a directory name.  For example, `new Table(new File("cars.dbf"))`

Added unit test TestUtil.getDbtFile_if_no_directory.
